### PR TITLE
MODOKAPFAC-4 Add mod-okapi-facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Application descriptor repository for app-platform-full. Comprised of all FOLIO 
 | `mod-notes`                 |
 | `mod-kb-ebsco-java`         |
 | `mod-eusage-reports`        |
+| `mod-okapi-facade`          |
 
 ## UI Modules
 

--- a/app-platform-full.template.json
+++ b/app-platform-full.template.json
@@ -368,6 +368,10 @@
     {
       "name": "mod-eusage-reports",
       "version": "latest"
+    },
+    {
+      "name": "mod-okapi-facade",
+      "version": "latest"
     }
   ],
   "uiModules": [


### PR DESCRIPTION
## Purpose
Add `mod-okapi-facade` to back-end modules list
US: [MODOKAPFAC-4](https://folio-org.atlassian.net/browse/MODOKAPFAC-4)
